### PR TITLE
Bug fix load model

### DIFF
--- a/graphcast/checkpoint.py
+++ b/graphcast/checkpoint.py
@@ -146,7 +146,7 @@ def _convert_types(typ: type[_T], value: Any) -> _T:
     return [_convert_types(value_type, v)
             for _, v in sorted(value.items(), key=lambda x: int(x[0]))]
 
-  if base_type is tuple:
+  if (base_type is tuple) and not isinstance(value, np.ndarray):
     if len(typ.__args__) == 2 and typ.__args__[1] == ...:
       # An arbitrary length tuple of a single type, eg: tuple[int, ...]
       value_type = typ.__args__[0]


### PR DESCRIPTION
Currently  loading of trained models does not work. An error occurs in `checkpoint.py/_convert_types`
where the `np.ndarray`s are treated as `tuples` for conversion. This PR just skips this check.
Note that loading pre-trained models from deepmind stored in GCS works without this change, so I wonder if there is a better fix that changes model saving instead.