### PR TITLE
Remove Variable Weight Warning

### DIFF
--- a/graphcast/graphcast.py
+++ b/graphcast/graphcast.py
@@ -26,7 +26,6 @@ a 2D mesh over latitudes and longitudes.
 """
 
 from typing import Any, Callable, Mapping, Optional
-import warnings
 
 import chex
 from graphcast import deep_typed_graph_net
@@ -442,7 +441,6 @@ class GraphCast(predictor_base.Predictor):
     for key in [t2m, u10m, v10m, psfc, precip]:
         if key not in targets:
             val = per_variable_weights.pop(key)
-            warnings.warn(f"Could not find {key} in targets dataset, will not add variable specific loss weighting of {val}")
 
     loss = losses.weighted_mse_per_level(
         predictions, targets,


### PR DESCRIPTION
This removes the really obnoxious warning when we do not include a variable that GraphCast defaults to using a non-unitary warning for (e.g. 2 m temperature). I made this long ago but I think we get the picture now.

@danielabdi-noaa I think you might appreciate this ... Let me know if you agree.