### PR TITLE
StackedGraphCast

### DIFF
--- a/graphcast/autoregressive.py
+++ b/graphcast/autoregressive.py
@@ -246,7 +246,7 @@ class Predictor(predictor_base.Predictor):
         return x + self._noise_level * jax.random.normal(
             hk.next_rng_key(), shape=x.shape)
       # Add noise to time-dependent variables of the inputs.
-      inputs = jax.tree_map(add_noise, inputs)
+      inputs = jax.tree_util.tree_map(add_noise, inputs)
 
     # The per-timestep targets passed by scan to one_step_loss below will have
     # no leading time axis. We need a treedef without the time axis to use

--- a/graphcast/casting.py
+++ b/graphcast/casting.py
@@ -140,7 +140,7 @@ def _all_inputs_to_bfloat16(
                xarray.Dataset,
                xarray.Dataset]:
   return (inputs.astype(jnp.bfloat16),
-          jax.tree_map(lambda x: x.astype(jnp.bfloat16), targets),
+          jax.tree.map(lambda x: x.astype(jnp.bfloat16), targets),
           forcings.astype(jnp.bfloat16))
 
 
@@ -149,7 +149,7 @@ def tree_map_cast(inputs: PyTree, input_dtype: np.dtype, output_dtype: np.dtype,
   def cast_fn(x):
     if x.dtype == input_dtype:
       return x.astype(output_dtype)
-  return jax.tree_map(cast_fn, inputs)
+  return jax.tree.map(cast_fn, inputs)
 
 
 @contextlib.contextmanager

--- a/graphcast/casting.py
+++ b/graphcast/casting.py
@@ -140,7 +140,7 @@ def _all_inputs_to_bfloat16(
                xarray.Dataset,
                xarray.Dataset]:
   return (inputs.astype(jnp.bfloat16),
-          jax.tree.map(lambda x: x.astype(jnp.bfloat16), targets),
+          jax.tree_util.tree_map(lambda x: x.astype(jnp.bfloat16), targets),
           forcings.astype(jnp.bfloat16))
 
 
@@ -149,7 +149,7 @@ def tree_map_cast(inputs: PyTree, input_dtype: np.dtype, output_dtype: np.dtype,
   def cast_fn(x):
     if x.dtype == input_dtype:
       return x.astype(output_dtype)
-  return jax.tree.map(cast_fn, inputs)
+  return jax.tree_util.tree_map(cast_fn, inputs)
 
 
 @contextlib.contextmanager

--- a/graphcast/graphcast.py
+++ b/graphcast/graphcast.py
@@ -163,6 +163,8 @@ class TaskConfig:
   forcing_variables: tuple[str, ...]
   pressure_levels: tuple[int, ...]
   input_duration: str
+  longitude: Optional[tuple[float, ...] | None] = None
+  latitude: Optional[tuple[float, ...] | None] = None
 
 TASK = TaskConfig(
     input_variables=(

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -15,6 +15,7 @@
 
 from typing import Mapping
 
+import chex
 from graphcast import xarray_tree
 import numpy as np
 from typing_extensions import Protocol

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -77,7 +77,7 @@ def stacked_mse(
     # return mean over all except channel dimension
     # recall prediction shape is (lat, lon, samples (batch), channels)
     loss_per_sample_channel = loss.mean(axis=(0,1))
-    loss_per_sample = loss_per_sample_channel.mean(axis=-1)
+    loss_per_sample = loss_per_sample_channel.sum(axis=-1)
     return loss_per_sample, loss_per_sample_channel
 
 

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -74,10 +74,9 @@ def stacked_mse(
     if weights is not None:
         loss *= weights
 
-    # return mean over all except channel dimension
     # recall prediction shape is (lat, lon, samples (batch), channels)
     loss_per_sample_channel = loss.mean(axis=(0,1))
-    loss_per_sample = loss_per_sample_channel.sum(axis=-1)
+    loss_per_sample = loss_per_sample_channel.mean(axis=-1)
     return loss_per_sample, loss_per_sample_channel
 
 

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -70,12 +70,21 @@ def stacked_mse(
         loss_per_sample_channel (chex.Array): total loss per channel and per sample
 
     """
+    # handle potential broadcasting to batch dimension
+    if predictions.ndim == 3:
+        latlon = (0, 1)
+    else:
+        latlon = (1, 2)
+        if weights is not None:
+            weights = weights[None] if weights.ndim == 3 else weights
+
+    # compute loss
     loss = (predictions - targets)**2
     if weights is not None:
         loss *= weights
 
-    # recall prediction shape is (lat, lon, samples (batch), channels)
-    loss_per_sample_channel = loss.mean(axis=(0,1))
+    # recall prediction shape is (samples (batch), lat, lon, channels)
+    loss_per_sample_channel = loss.mean(axis=latlon)
     loss_per_sample = loss_per_sample_channel.mean(axis=-1)
     return loss_per_sample, loss_per_sample_channel
 

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -52,6 +52,17 @@ class LossFunction(Protocol):
         batch before logging.
     """
 
+def stacked_mse(
+    predictions: chex.Array,
+    targets: chex.Array,
+    weights: chex.Array | None = None,
+) -> chex.Array:
+    """A very streamlined MSE loss function"""
+    loss = (prediction - targets)**2
+    if weights is not None:
+        loss *= weights
+    return loss.mean(axis=tuple(range(1, loss.ndim)))
+
 
 def weighted_mse_per_level(
     predictions: xarray.Dataset,

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -17,7 +17,7 @@ import contextlib
 from typing import Any, Mapping, Tuple
 
 import chex
-from graphcast import stacked_predictor_base
+from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndDiagnostics
 import haiku as hk
 import jax
 import jax.numpy as jnp
@@ -32,7 +32,7 @@ PyTree = Any
 class StackedBfloat16Cast(Bfloat16Cast):
   """Wrapper that casts all inputs to bfloat16 and outputs to targets dtype."""
 
-  def __init__(self, predictor: stacked_predictor_base.StackedPredictor, enabled: bool = True):
+  def __init__(self, predictor: StackedPredictor, enabled: bool = True):
     """Inits the wrapper.
 
     Args:
@@ -67,7 +67,7 @@ class StackedBfloat16Cast(Bfloat16Cast):
            inputs: chex.Array,
            targets: chex.Array,
            **kwargs,
-           ) -> chex.Array:
+           ) -> StackedLossAndDiagnostics:
     if not self._enabled:
       return self._predictor.loss(inputs, targets, forcings, **kwargs)
 
@@ -92,7 +92,7 @@ class StackedBfloat16Cast(Bfloat16Cast):
       inputs: chex.Array,
       targets: chex.Array,
       **kwargs,
-      ) -> Tuple[chex.Array,
+      ) -> Tuple[StackedLossAndDiagnostics,
                  chex.Array]:
     if not self._enabled:
       return self._predictor.loss_and_predictions(inputs, targets, forcings,  # pytype: disable=bad-return-type  # jax-ndarray

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -67,7 +67,7 @@ class StackedBfloat16Cast(Bfloat16Cast):
            inputs: chex.Array,
            targets: chex.Array,
            **kwargs,
-           ) -> stacked_predictor_base.LossAndDiagnostics:
+           ) -> chex.Array:
     if not self._enabled:
       return self._predictor.loss(inputs, targets, forcings, **kwargs)
 
@@ -92,7 +92,7 @@ class StackedBfloat16Cast(Bfloat16Cast):
       inputs: chex.Array,
       targets: chex.Array,
       **kwargs,
-      ) -> Tuple[stacked_predictor_base.LossAndDiagnostics,
+      ) -> Tuple[chex.Array,
                  chex.Array]:
     if not self._enabled:
       return self._predictor.loss_and_predictions(inputs, targets, forcings,  # pytype: disable=bad-return-type  # jax-ndarray

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -1,20 +1,7 @@
-# Copyright 2023 DeepMind Technologies Limited.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Wrappers that take care of casting."""
 
 import contextlib
-from typing import Any, Mapping, Tuple
+from typing import Any, Mapping, Tuple, Optional
 
 import chex
 from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndDiagnostics
@@ -24,170 +11,139 @@ import jax.numpy as jnp
 import numpy as np
 import xarray
 
-from graphcast.casting import Bfloat16Cast
-
-PyTree = Any
+from graphcast.casting import (
+    Bfloat16Cast,
+    tree_map_cast,
+    bfloat16_variable_view,
+    _bfloat16_creator,
+    _bfloat16_getter,
+    _bfloat16_setter,
+)
 
 
 class StackedBfloat16Cast(Bfloat16Cast):
-  """Wrapper that casts all inputs to bfloat16 and outputs to targets dtype."""
+    """Wrapper that casts all inputs to bfloat16 and outputs to targets dtype."""
 
-  def __init__(self, predictor: StackedPredictor, enabled: bool = True):
-    """Inits the wrapper.
+    def __init__(self, predictor: StackedPredictor, enabled: bool = True):
+        """Inits the wrapper.
 
-    Args:
-      predictor: predictor being wrapped.
-      enabled: disables the wrapper if False, for simpler hyperparameter scans.
+        Args:
+          predictor: predictor being wrapped.
+          enabled: disables the wrapper if False, for simpler hyperparameter scans.
 
-    """
-    self._enabled = enabled
-    self._predictor = predictor
+        """
+        self._enabled = enabled
+        self._predictor = predictor
 
-  def __call__(self,
-               inputs: chex.Array,
-               **kwargs
-               ) -> chex.Array:
-    if not self._enabled:
-      return self._predictor(inputs, **kwargs)
+    def __call__(
+        self,
+        inputs: chex.Array,
+        **kwargs
+        ) -> chex.Array:
+        if not self._enabled:
+            return self._predictor(inputs, **kwargs)
 
-    with bfloat16_variable_view():
-      predictions = self._predictor(
-          _inputs_to_bfloat16(inputs),
-          **kwargs,)
+        with bfloat16_variable_view():
+            predictions = self._predictor(
+                inputs.astype(jnp.bfloat16),
+                **kwargs,
+            )
 
-    predictions_dtype = infer_floating_dtype(predictions)  # pytype: disable=wrong-arg-types
-    if predictions_dtype != jnp.bfloat16:
-      raise ValueError(f'Expected bfloat16 output, got {predictions_dtype}')
+        predictions_dtype = infer_floating_dtype(predictions)  # pytype: disable=wrong-arg-types
+        if predictions_dtype != jnp.bfloat16:
+            raise ValueError(f'Expected bfloat16 output, got {predictions_dtype}')
 
-    targets_dtype = infer_floating_dtype(inputs)  # pytype: disable=wrong-arg-types
-    return tree_map_cast(
-        predictions, input_dtype=jnp.bfloat16, output_dtype=targets_dtype)
+        targets_dtype = infer_floating_dtype(inputs)  # pytype: disable=wrong-arg-types
+        return tree_map_cast(
+            predictions,
+            input_dtype=jnp.bfloat16,
+            output_dtype=targets_dtype,
+        )
 
-  def loss(self,
-           inputs: chex.Array,
-           targets: chex.Array,
-           **kwargs,
-           ) -> StackedLossAndDiagnostics:
-    if not self._enabled:
-      return self._predictor.loss(inputs, targets, forcings, **kwargs)
+    def loss(
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        weights: Optional[chex.Array | None] = None
+        ) -> StackedLossAndDiagnostics:
+        if not self._enabled:
+            return self._predictor.loss(inputs, targets, weights)
 
-    with bfloat16_variable_view():
-      loss, scalars = self._predictor.loss(
-          *_inputs_and_targets_to_bfloat16(inputs, targets), **kwargs)
+        with bfloat16_variable_view():
+            loss, scalars = self._predictor.loss(
+                *_inputs_targets_weights_to_bfloat16(
+                    inputs,
+                    targets,
+                    weights,
+                )
+            )
 
-    if loss.dtype != jnp.bfloat16:
-      raise ValueError(f'Expected bfloat16 loss, got {loss.dtype}')
+        if loss.dtype != jnp.bfloat16:
+            raise ValueError(f'Expected bfloat16 loss, got {loss.dtype}')
 
-    targets_dtype = infer_floating_dtype(targets)  # pytype: disable=wrong-arg-types
+        targets_dtype = infer_floating_dtype(targets)  # pytype: disable=wrong-arg-types
 
-    # Note that casting back the loss to e.g. float32 should not affect data
-    # types of the backwards pass, because the first thing the backwards pass
-    # should do is to go backwards the casting op and cast back to bfloat16
-    # (and xprofs seem to confirm this).
-    return tree_map_cast((loss, scalars),
-                         input_dtype=jnp.bfloat16, output_dtype=targets_dtype)
+        # Note that casting back the loss to e.g. float32 should not affect data
+        # types of the backwards pass, because the first thing the backwards pass
+        # should do is to go backwards the casting op and cast back to bfloat16
+        # (and xprofs seem to confirm this).
+        return tree_map_cast(
+            (loss, scalars),
+            input_dtype=jnp.bfloat16,
+            output_dtype=targets_dtype,
+        )
 
-  def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
-      self,
-      inputs: chex.Array,
-      targets: chex.Array,
-      **kwargs,
-      ) -> Tuple[StackedLossAndDiagnostics,
-                 chex.Array]:
-    if not self._enabled:
-      return self._predictor.loss_and_predictions(inputs, targets, forcings,  # pytype: disable=bad-return-type  # jax-ndarray
-                                                  **kwargs)
+    def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        weights: Optional[chex.Array | None] = None
+        ) -> Tuple[StackedLossAndDiagnostics,
+                   chex.Array]:
+        if not self._enabled:
+            return self._predictor.loss_and_predictions(
+                inputs,
+                targets,
+                weights,
+            )
 
-    with bfloat16_variable_view():
-      (loss, scalars), predictions = self._predictor.loss_and_predictions(
-          *_inputs_and_targets_to_bfloat16(inputs, targets), **kwargs)
+        with bfloat16_variable_view():
+            (loss, scalars), predictions = self._predictor.loss_and_predictions(
+                *_inputs_targets_weights_to_bfloat16(
+                    inputs,
+                    targets,
+                    weights,
+                )
+            )
 
-    if loss.dtype != jnp.bfloat16:
-      raise ValueError(f'Expected bfloat16 loss, got {loss.dtype}')
+        if loss.dtype != jnp.bfloat16:
+            raise ValueError(f'Expected bfloat16 loss, got {loss.dtype}')
 
-    predictions_dtype = infer_floating_dtype(predictions)  # pytype: disable=wrong-arg-types
-    if predictions_dtype != jnp.bfloat16:
-      raise ValueError(f'Expected bfloat16 output, got {predictions_dtype}')
+        predictions_dtype = infer_floating_dtype(predictions)  # pytype: disable=wrong-arg-types
+        if predictions_dtype != jnp.bfloat16:
+            raise ValueError(f'Expected bfloat16 output, got {predictions_dtype}')
 
-    targets_dtype = infer_floating_dtype(targets)  # pytype: disable=wrong-arg-types
-    return tree_map_cast(((loss, scalars), predictions),
-                         input_dtype=jnp.bfloat16, output_dtype=targets_dtype)
+        targets_dtype = infer_floating_dtype(targets)  # pytype: disable=wrong-arg-types
+        return tree_map_cast(
+            ((loss, scalars), predictions),
+            input_dtype=jnp.bfloat16,
+            output_dtype=targets_dtype,
+        )
 
 
 def infer_floating_dtype(array: chex.Array) -> np.dtype:
-  """Infers a floating dtype from an input mapping of data."""
-  return array.dtype if jnp.issubdtype(array.dtype, np.floating) else None
+    """Infers a floating dtype from an input mapping of data."""
+    return array.dtype if jnp.issubdtype(array.dtype, np.floating) else None
 
-def _inputs_to_bfloat16(
-    inputs: chex.Array,
-    ) -> chex.Array:
-  return inputs.astype(jnp.bfloat16)
-
-def _inputs_and_targets_to_bfloat16(
+def _inputs_targets_weights_to_bfloat16(
     inputs: chex.Array,
     targets: chex.Array,
+    weights: Optional[chex.Array | None] = None,
     ) -> Tuple[chex.Array,
+               chex.Array,
                chex.Array]:
-  return (inputs.astype(jnp.bfloat16),
-          jax.tree_map(lambda x: x.astype(jnp.bfloat16), targets))
 
-
-def tree_map_cast(inputs: PyTree, input_dtype: np.dtype, output_dtype: np.dtype,
-                  ) -> PyTree:
-  def cast_fn(x):
-    if x.dtype == input_dtype:
-      return x.astype(output_dtype)
-  return jax.tree_map(cast_fn, inputs)
-
-
-@contextlib.contextmanager
-def bfloat16_variable_view(enabled: bool = True):
-  """Context for Haiku modules with float32 params, but bfloat16 activations.
-
-  It works as follows:
-  * Every time a variable is requested to be created/set as np.bfloat16,
-    it will create an underlying float32 variable, instead.
-  * Every time a variable a variable is requested as bfloat16, it will check the
-    variable is of float32 type, and cast the variable to bfloat16.
-
-  Note the gradients are still computed and accumulated as float32, because
-  the params returned by init are float32, so the gradient function with
-  respect to the params will already include an implicit casting to float32.
-
-  Args:
-    enabled: Only enables bfloat16 behavior if True.
-
-  Yields:
-    None
-  """
-
-  if enabled:
-    with hk.custom_creator(
-        _bfloat16_creator, state=True), hk.custom_getter(
-            _bfloat16_getter, state=True), hk.custom_setter(
-                _bfloat16_setter):
-      yield
-  else:
-    yield
-
-
-def _bfloat16_creator(next_creator, shape, dtype, init, context):
-  """Creates float32 variables when bfloat16 is requested."""
-  if context.original_dtype == jnp.bfloat16:
-    dtype = jnp.float32
-  return next_creator(shape, dtype, init)
-
-
-def _bfloat16_getter(next_getter, value, context):
-  """Casts float32 to bfloat16 when bfloat16 was originally requested."""
-  if context.original_dtype == jnp.bfloat16:
-    assert value.dtype == jnp.float32
-    value = value.astype(jnp.bfloat16)
-  return next_getter(value)
-
-
-def _bfloat16_setter(next_setter, value, context):
-  """Casts bfloat16 to float32 when bfloat16 was originally set."""
-  if context.original_dtype == jnp.bfloat16:
-    value = value.astype(jnp.float32)
-  return next_setter(value)
+    i16 = inputs.astype(jnp.bfloat16)
+    t16 = jax.tree_map(lambda x: x.astype(jnp.bfloat16), targets)
+    w16 = weights.astype(jnp.bfloat16) if weights is not None else None
+    return i16, t16, w16

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -144,6 +144,6 @@ def _inputs_targets_weights_to_bfloat16(
                chex.Array]:
 
     i16 = inputs.astype(jnp.bfloat16)
-    t16 = jax.tree.map(lambda x: x.astype(jnp.bfloat16), targets)
+    t16 = jax.tree_util.tree_map(lambda x: x.astype(jnp.bfloat16), targets)
     w16 = weights.astype(jnp.bfloat16) if weights is not None else None
     return i16, t16, w16

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -144,6 +144,6 @@ def _inputs_targets_weights_to_bfloat16(
                chex.Array]:
 
     i16 = inputs.astype(jnp.bfloat16)
-    t16 = jax.tree_map(lambda x: x.astype(jnp.bfloat16), targets)
+    t16 = jax.tree.map(lambda x: x.astype(jnp.bfloat16), targets)
     w16 = weights.astype(jnp.bfloat16) if weights is not None else None
     return i16, t16, w16

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -1,0 +1,193 @@
+# Copyright 2023 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wrappers that take care of casting."""
+
+import contextlib
+from typing import Any, Mapping, Tuple
+
+import chex
+from graphcast import stacked_predictor_base
+import haiku as hk
+import jax
+import jax.numpy as jnp
+import numpy as np
+import xarray
+
+from graphcast.casting import Bfloat16Cast
+
+PyTree = Any
+
+
+class StackedBfloat16Cast(Bfloat16Cast):
+  """Wrapper that casts all inputs to bfloat16 and outputs to targets dtype."""
+
+  def __init__(self, predictor: stacked_predictor_base.StackedPredictor, enabled: bool = True):
+    """Inits the wrapper.
+
+    Args:
+      predictor: predictor being wrapped.
+      enabled: disables the wrapper if False, for simpler hyperparameter scans.
+
+    """
+    self._enabled = enabled
+    self._predictor = predictor
+
+  def __call__(self,
+               inputs: chex.Array,
+               **kwargs
+               ) -> chex.Array:
+    if not self._enabled:
+      return self._predictor(inputs, **kwargs)
+
+    with bfloat16_variable_view():
+      predictions = self._predictor(
+          _inputs_to_bfloat16(inputs),
+          **kwargs,)
+
+    predictions_dtype = infer_floating_dtype(predictions)  # pytype: disable=wrong-arg-types
+    if predictions_dtype != jnp.bfloat16:
+      raise ValueError(f'Expected bfloat16 output, got {predictions_dtype}')
+
+    targets_dtype = infer_floating_dtype(inputs)  # pytype: disable=wrong-arg-types
+    return tree_map_cast(
+        predictions, input_dtype=jnp.bfloat16, output_dtype=targets_dtype)
+
+  def loss(self,
+           inputs: chex.Array,
+           targets: chex.Array,
+           **kwargs,
+           ) -> stacked_predictor_base.LossAndDiagnostics:
+    if not self._enabled:
+      return self._predictor.loss(inputs, targets, forcings, **kwargs)
+
+    with bfloat16_variable_view():
+      loss, scalars = self._predictor.loss(
+          *_inputs_and_targets_to_bfloat16(inputs, targets), **kwargs)
+
+    if loss.dtype != jnp.bfloat16:
+      raise ValueError(f'Expected bfloat16 loss, got {loss.dtype}')
+
+    targets_dtype = infer_floating_dtype(targets)  # pytype: disable=wrong-arg-types
+
+    # Note that casting back the loss to e.g. float32 should not affect data
+    # types of the backwards pass, because the first thing the backwards pass
+    # should do is to go backwards the casting op and cast back to bfloat16
+    # (and xprofs seem to confirm this).
+    return tree_map_cast((loss, scalars),
+                         input_dtype=jnp.bfloat16, output_dtype=targets_dtype)
+
+  def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      inputs: chex.Array,
+      targets: chex.Array,
+      **kwargs,
+      ) -> Tuple[stacked_predictor_base.LossAndDiagnostics,
+                 chex.Array]:
+    if not self._enabled:
+      return self._predictor.loss_and_predictions(inputs, targets, forcings,  # pytype: disable=bad-return-type  # jax-ndarray
+                                                  **kwargs)
+
+    with bfloat16_variable_view():
+      (loss, scalars), predictions = self._predictor.loss_and_predictions(
+          *_inputs_and_targets_to_bfloat16(inputs, targets), **kwargs)
+
+    if loss.dtype != jnp.bfloat16:
+      raise ValueError(f'Expected bfloat16 loss, got {loss.dtype}')
+
+    predictions_dtype = infer_floating_dtype(predictions)  # pytype: disable=wrong-arg-types
+    if predictions_dtype != jnp.bfloat16:
+      raise ValueError(f'Expected bfloat16 output, got {predictions_dtype}')
+
+    targets_dtype = infer_floating_dtype(targets)  # pytype: disable=wrong-arg-types
+    return tree_map_cast(((loss, scalars), predictions),
+                         input_dtype=jnp.bfloat16, output_dtype=targets_dtype)
+
+
+def infer_floating_dtype(array: chex.Array) -> np.dtype:
+  """Infers a floating dtype from an input mapping of data."""
+  return array.dtype if jnp.issubdtype(array.dtype, np.floating) else None
+
+def _inputs_to_bfloat16(
+    inputs: chex.Array,
+    ) -> chex.Array:
+  return inputs.astype(jnp.bfloat16)
+
+def _inputs_and_targets_to_bfloat16(
+    inputs: chex.Array,
+    targets: chex.Array,
+    ) -> Tuple[chex.Array,
+               chex.Array]:
+  return (inputs.astype(jnp.bfloat16),
+          jax.tree_map(lambda x: x.astype(jnp.bfloat16), targets))
+
+
+def tree_map_cast(inputs: PyTree, input_dtype: np.dtype, output_dtype: np.dtype,
+                  ) -> PyTree:
+  def cast_fn(x):
+    if x.dtype == input_dtype:
+      return x.astype(output_dtype)
+  return jax.tree_map(cast_fn, inputs)
+
+
+@contextlib.contextmanager
+def bfloat16_variable_view(enabled: bool = True):
+  """Context for Haiku modules with float32 params, but bfloat16 activations.
+
+  It works as follows:
+  * Every time a variable is requested to be created/set as np.bfloat16,
+    it will create an underlying float32 variable, instead.
+  * Every time a variable a variable is requested as bfloat16, it will check the
+    variable is of float32 type, and cast the variable to bfloat16.
+
+  Note the gradients are still computed and accumulated as float32, because
+  the params returned by init are float32, so the gradient function with
+  respect to the params will already include an implicit casting to float32.
+
+  Args:
+    enabled: Only enables bfloat16 behavior if True.
+
+  Yields:
+    None
+  """
+
+  if enabled:
+    with hk.custom_creator(
+        _bfloat16_creator, state=True), hk.custom_getter(
+            _bfloat16_getter, state=True), hk.custom_setter(
+                _bfloat16_setter):
+      yield
+  else:
+    yield
+
+
+def _bfloat16_creator(next_creator, shape, dtype, init, context):
+  """Creates float32 variables when bfloat16 is requested."""
+  if context.original_dtype == jnp.bfloat16:
+    dtype = jnp.float32
+  return next_creator(shape, dtype, init)
+
+
+def _bfloat16_getter(next_getter, value, context):
+  """Casts float32 to bfloat16 when bfloat16 was originally requested."""
+  if context.original_dtype == jnp.bfloat16:
+    assert value.dtype == jnp.float32
+    value = value.astype(jnp.bfloat16)
+  return next_getter(value)
+
+
+def _bfloat16_setter(next_setter, value, context):
+  """Casts bfloat16 to float32 when bfloat16 was originally set."""
+  if context.original_dtype == jnp.bfloat16:
+    value = value.astype(jnp.float32)
+  return next_setter(value)

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -61,18 +61,14 @@ class StackedGraphCast(graphcast.GraphCast):
         self,
         inputs: chex.Array,
         targets: chex.Array,
-        ) -> tuple[predictor_base.LossAndDiagnostics, chex.Array]:
+        ) -> tuple[chex.Array, chex.Array]:
         # Forward pass
         predictions = self(inputs)
 
-        # bump to xarray.DataArray in order to hookup to losses module
-        dims = ("lat", "lon", "channels")
-
         # Compute loss
-        loss = losses.weighted_mse_per_level(
+        loss = losses.stacked_mse(
             predictions,
             targets,
-            per_variable_weights=dict(),
         )
         return loss, predictions
 

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -120,7 +120,7 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         self,
         grid_node_outputs: chex.Array,
         ) -> chex.Array:
-        """returned as [batch, lat, lon, channels]"""
+        """returned as [batch, lat, lon, channels] or [lat, lon, channels]"""
 
         assert self._grid_lat is not None and self._grid_lon is not None
         grid_shape = (self._grid_lat.shape[0], self._grid_lon.shape[0])

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -1,0 +1,123 @@
+
+import xarray
+import chex
+import jax.numpy as jnp
+import numpy as np
+
+from graphcast import graphcast
+from graphcast import predictor_base
+from graphcast import xarray_jax
+
+class StackedGraphCast(graphcast.GraphCast):
+
+    def __init__(
+        self,
+        model_config: graphcast.ModelConfig,
+        task_config: graphcast.TaskConfig
+        ):
+        super().__init__(model_config=model_config, task_config=task_config)
+
+        # since we don't use xarray DataArrays as inputs, we have to
+        # establish the grid somehow. Seems easiest to pass it via task_config
+        # just like the pressure levels
+        self._init_grid_properties(
+            grid_lat=np.array(task_config.latitude),
+            grid_lon=np.array(task_config.longitude),
+        )
+
+
+    def __call__(
+        self,
+        inputs: chex.Array,
+        # I don't think we need anything else
+        targets_template: chex.Array = None,
+        forcings: chex.Array | None = None,
+        is_training: bool = False,
+        ) -> chex.Array:
+
+        self._maybe_init()
+
+        # Convert all input data into flat vectors for each of the grid nodes.
+        # xarray (batch, time, lat, lon, level, multiple vars, forcings)
+        # -> [num_grid_nodes, batch, num_channels]
+        grid_node_features = self._inputs_to_grid_node_features(inputs)
+
+        # Transfer data for the grid to the mesh,
+        # [num_mesh_nodes, batch, latent_size], [num_grid_nodes, batch, latent_size]
+        (latent_mesh_nodes, latent_grid_nodes
+         ) = self._run_grid2mesh_gnn(grid_node_features)
+
+        # Run message passing in the multimesh.
+        # [num_mesh_nodes, batch, latent_size]
+        updated_latent_mesh_nodes = self._run_mesh_gnn(latent_mesh_nodes)
+
+        # Transfer data frome the mesh to the grid.
+        # [num_grid_nodes, batch, output_size]
+        output_grid_nodes = self._run_mesh2grid_gnn(
+            updated_latent_mesh_nodes, latent_grid_nodes)
+
+        # Conver output flat vectors for the grid nodes to the format of the output.
+        # [num_grid_nodes, batch, output_size] ->
+        # xarray (batch, one time step, lat, lon, level, multiple vars)
+        return self._grid_node_outputs_to_prediction(
+            output_grid_nodes, targets_template)
+
+    def loss_and_predictions(
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        forcings: chex.Array | None = None,
+        ) -> tuple[predictor_base.LossAndDiagnostics, chex.Array]:
+        # Forward pass
+        predictions = self(inputs)
+
+        # bump to xarray.DataArray in order to hookup to losses module
+        dims = ("lat", "lon", "channels")
+
+
+        # Compute loss
+        loss = losses.weighted_mse_per_level(
+            predictions,
+            targets,
+            per_variable_weights=dict(),
+        )
+        return loss, predictions
+
+
+    def _maybe_init(self):
+        if not self._initialized:
+            self._init_mesh_properties()
+            # grid properties initialized at __init__
+            self._grid2mesh_graph_structure = self._init_grid2mesh_graph()
+            self._mesh_graph_structure = self._init_mesh_graph()
+            self._mesh2grid_graph_structure = self._init_mesh2grid_graph()
+
+            self._initialized = True
+
+
+    def _inputs_to_grid_node_features(
+        self,
+        inputs: chex.Array,
+        ) -> chex.Array:
+        """inputs expected to be as [lat, lon, ...]"""
+
+        shape = (-1,) + inputs.shape[2:]
+        result = xarray_jax.unwrap(inputs)
+        result = result.reshape(shape)
+        return result
+
+    def _grid_node_outputs_to_prediction(
+        self,
+        grid_node_outputs: chex.Array,
+        targets_template: xarray.Dataset | None = None,
+        ) -> chex.Array:
+        """returned as [lat, lon, ...]"""
+
+        assert self._grid_lat is not None and self._grid_lon is not None
+        grid_shape = (self._grid_lat.shape[0], self._grid_lon.shape[0])
+
+        # result is [lat, lon, batch, channels]
+        result = grid_node_outputs.reshape(
+            grid_shape + grid_node_outputs.shape[1:],
+        )
+        return result

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -113,7 +113,6 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         result = np.moveaxis(inputs, 0, 2)
 
         shape = (-1,) + result.shape[2:]
-        result = xarray_jax.unwrap(result)
         result = result.reshape(shape)
         return result
 

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -1,5 +1,5 @@
 
-
+from typing import Optional
 import xarray
 import chex
 import jax.numpy as jnp
@@ -63,24 +63,27 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         self,
         inputs: chex.Array,
         targets: chex.Array,
+        weights: Optional[chex.Array | None] = None,
         ) -> tuple[StackedLossAndDiagnostics, chex.Array]:
         # Forward pass
         predictions = self(inputs)
 
         # Compute loss
-        loss = stacked_mse(
-            predictions,
-            targets,
+        loss, diagnostics = stacked_mse(
+            predictions=predictions,
+            targets=targets,
+            weights=weights,
         )
-        return loss, predictions
+        return (loss, diagnostics), predictions
 
     def loss(
         self,
         inputs: chex.Array,
         targets: chex.Array,
+        weights: Optional[chex.Array | None] = None,
         ) -> StackedLossAndDiagnostics:
-        loss, _ = self.loss_and_predictions(inputs, targets)
-        return loss
+        (loss, diagnostics), _ = self.loss_and_predictions(inputs, targets, weights)
+        return loss, diagnostics
 
 
     def _maybe_init(self):

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -29,10 +29,6 @@ class StackedGraphCast(graphcast.GraphCast):
     def __call__(
         self,
         inputs: chex.Array,
-        # I don't think we need anything else
-        targets_template: chex.Array = None,
-        forcings: chex.Array | None = None,
-        is_training: bool = False,
         ) -> chex.Array:
 
         self._maybe_init()
@@ -59,21 +55,18 @@ class StackedGraphCast(graphcast.GraphCast):
         # Conver output flat vectors for the grid nodes to the format of the output.
         # [num_grid_nodes, batch, output_size] ->
         # xarray (batch, one time step, lat, lon, level, multiple vars)
-        return self._grid_node_outputs_to_prediction(
-            output_grid_nodes, targets_template)
+        return self._grid_node_outputs_to_prediction(output_grid_nodes)
 
     def loss_and_predictions(
         self,
         inputs: chex.Array,
         targets: chex.Array,
-        forcings: chex.Array | None = None,
         ) -> tuple[predictor_base.LossAndDiagnostics, chex.Array]:
         # Forward pass
         predictions = self(inputs)
 
         # bump to xarray.DataArray in order to hookup to losses module
         dims = ("lat", "lon", "channels")
-
 
         # Compute loss
         loss = losses.weighted_mse_per_level(
@@ -109,7 +102,6 @@ class StackedGraphCast(graphcast.GraphCast):
     def _grid_node_outputs_to_prediction(
         self,
         grid_node_outputs: chex.Array,
-        targets_template: xarray.Dataset | None = None,
         ) -> chex.Array:
         """returned as [lat, lon, ...]"""
 

--- a/graphcast/stacked_normalization.py
+++ b/graphcast/stacked_normalization.py
@@ -1,0 +1,179 @@
+# Copyright 2023 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wrappers for Predictors which allow them to work with normalized data.
+
+The Predictor which is wrapped sees normalized inputs and targets, and makes
+normalized predictions. The wrapper handles translating the predictions back
+to the original domain.
+"""
+
+import logging
+import chex
+from typing import Optional, Tuple
+
+from graphcast import predictor_base
+from graphcast import xarray_tree
+import xarray
+
+
+def normalize(values: chex.Array,
+              scales: chex.Array,
+              locations: Optional[chex.Array],
+              ) -> chex.Array:
+    """Normalize variables using the given scales and (optionally) locations."""
+    if locations is not None:
+        result = values - locations.astype(values.dtype)
+    else:
+        result = values
+
+    result = result / scales.astype(values.dtype)
+    return result
+
+
+def unnormalize(values: chex.Array,
+                scales: chex.Array,
+                locations: Optional[chex.Array],
+                ) -> chex.Array:
+    """Unnormalize variables using the given scales and (optionally) locations."""
+    result = values * scales.astype(values.dtype)
+
+    if locations is not None:
+        result = result + locations.astype(values.dtype)
+    return result
+
+
+class InputsAndResiduals(stacked_predictor_base.StackedPredictor):
+  """Wraps with a residual connection, normalizing inputs and target residuals.
+
+  The inner predictor is given inputs that are normalized using `locations`
+  and `scales` to roughly zero-mean unit variance.
+
+  For target variables that are present in the inputs, the inner predictor is
+  trained to predict residuals (target - last_frame_of_input) that have been
+  normalized using `residual_scales` (and optionally `residual_locations`) to
+  roughly unit variance / zero mean.
+
+  This replaces `residual.Predictor` in the case where you want normalization
+  that's based on the scales of the residuals.
+
+  Since we return the underlying predictor's loss on the normalized residuals,
+  if the underlying predictor is a sum of per-variable losses, the normalization
+  will affect the relative weighting of the per-variable loss terms (hopefully
+  in a good way).
+
+  For target variables *not* present in the inputs, the inner predictor is
+  trained to predict targets directly, that have been normalized in the same
+  way as the inputs.
+
+  The transforms applied to the targets (the residual connection and the
+  normalization) are applied in reverse to the predictions before returning
+  them.
+  """
+
+  def __init__(
+      self,
+      predictor: stacked_predictor_base.StackedPredictor,
+      stddev_by_level: chex.Array,
+      mean_by_level: chex.Array,
+      diffs_stddev_by_level: chex.Array):
+    self._predictor = predictor
+    self._scales = stddev_by_level
+    self._locations = mean_by_level
+    self._residual_scales = diffs_stddev_by_level
+    self._residual_locations = None
+
+  def _unnormalize_prediction_and_add_input(self, inputs, norm_prediction):
+    if norm_prediction.sizes.get('time') != 1:
+      raise ValueError(
+          'normalization.InputsAndResiduals only supports predicting a '
+          'single timestep.')
+    if norm_prediction.name in inputs:
+      # Residuals are assumed to be predicted as normalized (unit variance),
+      # but the scale and location they need mapping to is that of the residuals
+      # not of the values themselves.
+      prediction = unnormalize(
+          norm_prediction, self._residual_scales, self._residual_locations)
+      # A prediction for which we have a corresponding input -- we are
+      # predicting the residual:
+      last_input = inputs[norm_prediction.name].isel(time=-1)
+      prediction = prediction + last_input
+      return prediction
+    else:
+      # A predicted variable which is not an input variable. We are predicting
+      # it directly, so unnormalize it directly to the target scale/location:
+      return unnormalize(norm_prediction, self._scales, self._locations)
+
+  def _subtract_input_and_normalize_target(self, inputs, target):
+    if target.sizes.get('time') != 1:
+      raise ValueError(
+          'normalization.InputsAndResiduals only supports wrapping predictors'
+          'that predict a single timestep.')
+    if target.name in inputs:
+      target_residual = target
+      last_input = inputs[target.name].isel(time=-1)
+      target_residual = target_residual - last_input
+      return normalize(
+          target_residual, self._residual_scales, self._residual_locations)
+    else:
+      return normalize(target, self._scales, self._locations)
+
+  def __call__(self,
+               inputs: xarray.Dataset,
+               targets_template: xarray.Dataset,
+               forcings: xarray.Dataset,
+               **kwargs
+               ) -> xarray.Dataset:
+    norm_inputs = normalize(inputs, self._scales, self._locations)
+    norm_forcings = normalize(forcings, self._scales, self._locations)
+    norm_predictions = self._predictor(
+        norm_inputs, targets_template, forcings=norm_forcings, **kwargs)
+    return xarray_tree.map_structure(
+        lambda pred: self._unnormalize_prediction_and_add_input(inputs, pred),
+        norm_predictions)
+
+  def loss(self,
+           inputs: xarray.Dataset,
+           targets: xarray.Dataset,
+           forcings: xarray.Dataset,
+           **kwargs,
+           ) -> predictor_base.LossAndDiagnostics:
+    """Returns the loss computed on normalized inputs and targets."""
+    norm_inputs = normalize(inputs, self._scales, self._locations)
+    norm_forcings = normalize(forcings, self._scales, self._locations)
+    norm_target_residuals = xarray_tree.map_structure(
+        lambda t: self._subtract_input_and_normalize_target(inputs, t),
+        targets)
+    return self._predictor.loss(
+        norm_inputs, norm_target_residuals, forcings=norm_forcings, **kwargs)
+
+  def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      inputs: xarray.Dataset,
+      targets: xarray.Dataset,
+      forcings: xarray.Dataset,
+      **kwargs,
+      ) -> Tuple[predictor_base.LossAndDiagnostics,
+                 xarray.Dataset]:
+    """The loss computed on normalized data, with unnormalized predictions."""
+    norm_inputs = normalize(inputs, self._scales, self._locations)
+    norm_forcings = normalize(forcings, self._scales, self._locations)
+    norm_target_residuals = xarray_tree.map_structure(
+        lambda t: self._subtract_input_and_normalize_target(inputs, t),
+        targets)
+    (loss, scalars), norm_predictions = self._predictor.loss_and_predictions(
+        norm_inputs, norm_target_residuals, forcings=norm_forcings, **kwargs)
+    predictions = xarray_tree.map_structure(
+        lambda pred: self._unnormalize_prediction_and_add_input(inputs, pred),
+        norm_predictions)
+    return (loss, scalars), predictions

--- a/graphcast/stacked_normalization.py
+++ b/graphcast/stacked_normalization.py
@@ -1,16 +1,3 @@
-# Copyright 2023 DeepMind Technologies Limited.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Wrappers for Predictors which allow them to work with normalized data.
 
 The Predictor which is wrapped sees normalized inputs and targets, and makes
@@ -22,7 +9,7 @@ import logging
 import chex
 from typing import Optional, Tuple
 
-from graphcast import predictor_base
+from graphcast import stacked_predictor_base
 from graphcast import xarray_tree
 import xarray
 
@@ -32,12 +19,11 @@ def normalize(values: chex.Array,
               locations: Optional[chex.Array],
               ) -> chex.Array:
     """Normalize variables using the given scales and (optionally) locations."""
+    result = values
     if locations is not None:
-        result = values - locations.astype(values.dtype)
-    else:
-        result = values
+        result -= locations#.astype(values.dtype)
 
-    result = result / scales.astype(values.dtype)
+    result = result / scales#.astype(values.dtype)
     return result
 
 
@@ -46,134 +32,107 @@ def unnormalize(values: chex.Array,
                 locations: Optional[chex.Array],
                 ) -> chex.Array:
     """Unnormalize variables using the given scales and (optionally) locations."""
-    result = values * scales.astype(values.dtype)
+    result = values * scales#.astype(values.dtype)
 
     if locations is not None:
-        result = result + locations.astype(values.dtype)
+        result += locations#.astype(values.dtype)
     return result
 
 
-class InputsAndResiduals(stacked_predictor_base.StackedPredictor):
-  """Wraps with a residual connection, normalizing inputs and target residuals.
+class StackedInputsAndResiduals(stacked_predictor_base.StackedPredictor):
+    """Wraps with a residual connection, normalizing inputs and target residuals.
 
-  The inner predictor is given inputs that are normalized using `locations`
-  and `scales` to roughly zero-mean unit variance.
+    The inner predictor is given inputs that are normalized using `locations`
+    and `scales` to roughly zero-mean unit variance.
 
-  For target variables that are present in the inputs, the inner predictor is
-  trained to predict residuals (target - last_frame_of_input) that have been
-  normalized using `residual_scales` (and optionally `residual_locations`) to
-  roughly unit variance / zero mean.
+    For target variables that are present in the inputs, the inner predictor is
+    trained to predict residuals (target - last_frame_of_input) that have been
+    normalized using `residual_scales` (and optionally `residual_locations`) to
+    roughly unit variance / zero mean.
 
-  This replaces `residual.Predictor` in the case where you want normalization
-  that's based on the scales of the residuals.
+    This replaces `residual.Predictor` in the case where you want normalization
+    that's based on the scales of the residuals.
 
-  Since we return the underlying predictor's loss on the normalized residuals,
-  if the underlying predictor is a sum of per-variable losses, the normalization
-  will affect the relative weighting of the per-variable loss terms (hopefully
-  in a good way).
+    Since we return the underlying predictor's loss on the normalized residuals,
+    if the underlying predictor is a sum of per-variable losses, the normalization
+    will affect the relative weighting of the per-variable loss terms (hopefully
+    in a good way).
 
-  For target variables *not* present in the inputs, the inner predictor is
-  trained to predict targets directly, that have been normalized in the same
-  way as the inputs.
+    For target variables *not* present in the inputs, the inner predictor is
+    trained to predict targets directly, that have been normalized in the same
+    way as the inputs.
 
-  The transforms applied to the targets (the residual connection and the
-  normalization) are applied in reverse to the predictions before returning
-  them.
-  """
+    The transforms applied to the targets (the residual connection and the
+    normalization) are applied in reverse to the predictions before returning
+    them.
+    """
 
-  def __init__(
-      self,
-      predictor: stacked_predictor_base.StackedPredictor,
-      stddev_by_level: chex.Array,
-      mean_by_level: chex.Array,
-      diffs_stddev_by_level: chex.Array):
-    self._predictor = predictor
-    self._scales = stddev_by_level
-    self._locations = mean_by_level
-    self._residual_scales = diffs_stddev_by_level
-    self._residual_locations = None
+    def __init__(
+        self,
+        predictor: stacked_predictor_base.StackedPredictor,
+        stddev_by_level: chex.Array,
+        mean_by_level: chex.Array,
+        diffs_stddev_by_level: chex.Array,
+        last_input_channel_mapping: dict,
+        ):
+        self._predictor = predictor
+        self._scales = stddev_by_level
+        self._locations = mean_by_level
+        self._residual_scales = diffs_stddev_by_level
+        self._residual_locations = None
+        self._last_input_channel_mapping = last_input_channel_mapping
 
-  def _unnormalize_prediction_and_add_input(self, inputs, norm_prediction):
-    if norm_prediction.sizes.get('time') != 1:
-      raise ValueError(
-          'normalization.InputsAndResiduals only supports predicting a '
-          'single timestep.')
-    if norm_prediction.name in inputs:
-      # Residuals are assumed to be predicted as normalized (unit variance),
-      # but the scale and location they need mapping to is that of the residuals
-      # not of the values themselves.
-      prediction = unnormalize(
-          norm_prediction, self._residual_scales, self._residual_locations)
-      # A prediction for which we have a corresponding input -- we are
-      # predicting the residual:
-      last_input = inputs[norm_prediction.name].isel(time=-1)
-      prediction = prediction + last_input
-      return prediction
-    else:
-      # A predicted variable which is not an input variable. We are predicting
-      # it directly, so unnormalize it directly to the target scale/location:
-      return unnormalize(norm_prediction, self._scales, self._locations)
+    def _unnormalize_prediction_and_add_input(self, inputs, norm_prediction):
+        """
+        arrays have shape [lat, lon, batch, time, channels]
+        Note:
+            Assumes that all prediction variables are also inputs!!
+        """
 
-  def _subtract_input_and_normalize_target(self, inputs, target):
-    if target.sizes.get('time') != 1:
-      raise ValueError(
-          'normalization.InputsAndResiduals only supports wrapping predictors'
-          'that predict a single timestep.')
-    if target.name in inputs:
-      target_residual = target
-      last_input = inputs[target.name].isel(time=-1)
-      target_residual = target_residual - last_input
-      return normalize(
-          target_residual, self._residual_scales, self._residual_locations)
-    else:
-      return normalize(target, self._scales, self._locations)
+        # grab the predictions that are also inputs, normalize these with residuals
+        prediction = unnormalize(norm_prediction, self._residual_scales, self._residual_locations)
+        last_input = inputs[..., list(self._last_input_channel_mapping.values())]
+        prediction += last_input
+        return prediction
 
-  def __call__(self,
-               inputs: xarray.Dataset,
-               targets_template: xarray.Dataset,
-               forcings: xarray.Dataset,
-               **kwargs
-               ) -> xarray.Dataset:
-    norm_inputs = normalize(inputs, self._scales, self._locations)
-    norm_forcings = normalize(forcings, self._scales, self._locations)
-    norm_predictions = self._predictor(
-        norm_inputs, targets_template, forcings=norm_forcings, **kwargs)
-    return xarray_tree.map_structure(
-        lambda pred: self._unnormalize_prediction_and_add_input(inputs, pred),
-        norm_predictions)
+    def _subtract_input_and_normalize_target(self, inputs, target):
+        last_input = inputs[..., list(self._last_input_channel_mapping.values())]
+        target_residual = target - last_input
+        return normalize(target_residual, self._residual_scales, self._residual_locations)
 
-  def loss(self,
-           inputs: xarray.Dataset,
-           targets: xarray.Dataset,
-           forcings: xarray.Dataset,
-           **kwargs,
-           ) -> predictor_base.LossAndDiagnostics:
-    """Returns the loss computed on normalized inputs and targets."""
-    norm_inputs = normalize(inputs, self._scales, self._locations)
-    norm_forcings = normalize(forcings, self._scales, self._locations)
-    norm_target_residuals = xarray_tree.map_structure(
-        lambda t: self._subtract_input_and_normalize_target(inputs, t),
-        targets)
-    return self._predictor.loss(
-        norm_inputs, norm_target_residuals, forcings=norm_forcings, **kwargs)
+    def __call__(
+        self,
+        inputs: chex.Array,
+        **kwargs
+        ) -> chex.Array:
+        norm_inputs = normalize(inputs, self._scales, self._locations)
+        norm_predictions = self._predictor(norm_inputs, **kwargs)
+        return self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
 
-  def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
-      self,
-      inputs: xarray.Dataset,
-      targets: xarray.Dataset,
-      forcings: xarray.Dataset,
-      **kwargs,
-      ) -> Tuple[predictor_base.LossAndDiagnostics,
-                 xarray.Dataset]:
-    """The loss computed on normalized data, with unnormalized predictions."""
-    norm_inputs = normalize(inputs, self._scales, self._locations)
-    norm_forcings = normalize(forcings, self._scales, self._locations)
-    norm_target_residuals = xarray_tree.map_structure(
-        lambda t: self._subtract_input_and_normalize_target(inputs, t),
-        targets)
-    (loss, scalars), norm_predictions = self._predictor.loss_and_predictions(
-        norm_inputs, norm_target_residuals, forcings=norm_forcings, **kwargs)
-    predictions = xarray_tree.map_structure(
-        lambda pred: self._unnormalize_prediction_and_add_input(inputs, pred),
-        norm_predictions)
-    return (loss, scalars), predictions
+    def loss(
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        **kwargs,
+        ) -> chex.Array:
+        """Returns the loss computed on normalized inputs and targets."""
+        norm_inputs = normalize(inputs, self._scales, self._locations)
+        norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
+        return self._predictor.loss(norm_inputs, norm_target_residuals, **kwargs)
+
+    def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        **kwargs,
+        ) -> Tuple[chex.Array, chex.Array]:
+        """Returns the loss computed on normalized inputs and targets."""
+        norm_inputs = normalize(inputs, self._scales, self._locations)
+        norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
+        (loss, scalars), norm_predictions = self._predictor.loss_and_predictions(
+            norm_inputs,
+            norm_target_residuals,
+            **kwargs,
+        )
+        predictions = self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
+        return (loss, scalars), predictions

--- a/graphcast/stacked_normalization.py
+++ b/graphcast/stacked_normalization.py
@@ -9,7 +9,7 @@ import logging
 import chex
 from typing import Optional, Tuple
 
-from graphcast import stacked_predictor_base
+from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndDiagnostics
 from graphcast import xarray_tree
 import xarray
 
@@ -39,7 +39,7 @@ def unnormalize(values: chex.Array,
     return result
 
 
-class StackedInputsAndResiduals(stacked_predictor_base.StackedPredictor):
+class StackedInputsAndResiduals(StackedPredictor):
     """Wraps with a residual connection, normalizing inputs and target residuals.
 
     The inner predictor is given inputs that are normalized using `locations`
@@ -69,7 +69,7 @@ class StackedInputsAndResiduals(stacked_predictor_base.StackedPredictor):
 
     def __init__(
         self,
-        predictor: stacked_predictor_base.StackedPredictor,
+        predictor: StackedPredictor,
         stddev_by_level: dict[chex.Array, chex.Array],
         mean_by_level: dict[chex.Array, chex.Array],
         diffs_stddev_by_level: dict[chex.Array, chex.Array],
@@ -136,7 +136,7 @@ class StackedInputsAndResiduals(stacked_predictor_base.StackedPredictor):
         inputs: chex.Array,
         targets: chex.Array,
         **kwargs,
-        ) -> chex.Array:
+        ) -> StackedLossAndDiagnostics:
         """Returns the loss computed on normalized inputs and targets."""
         norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
         norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
@@ -147,7 +147,7 @@ class StackedInputsAndResiduals(stacked_predictor_base.StackedPredictor):
         inputs: chex.Array,
         targets: chex.Array,
         **kwargs,
-        ) -> Tuple[chex.Array, chex.Array]:
+        ) -> Tuple[StackedLossAndDiagnostics, chex.Array]:
         """Returns the loss computed on normalized inputs and targets."""
         norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
         norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)

--- a/graphcast/stacked_predictor_base.py
+++ b/graphcast/stacked_predictor_base.py
@@ -1,21 +1,6 @@
-# Copyright 2023 DeepMind Technologies Limited.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-"""Abstract base classes for an xarray-based Predictor API."""
-
 import abc
 
-from typing import Tuple
+from typing import Tuple, Optional
 
 from graphcast import losses
 from graphcast import xarray_jax
@@ -23,7 +8,7 @@ import jax.numpy as jnp
 import xarray
 import chex
 
-LossAndDiagnostics = losses.LossAndDiagnostics
+StackedLossAndDiagnostics = losses.StackedLossAndDiagnostics
 
 
 class StackedPredictor(abc.ABC):
@@ -71,7 +56,7 @@ class StackedPredictor(abc.ABC):
            inputs: chex.Array,
            targets: chex.Array,
            **optional_kwargs,
-           ) -> LossAndDiagnostics:
+           ) -> StackedLossAndDiagnostics:
     """Computes a training loss, for predictors that are trainable.
 
     Why make this the Predictor's responsibility, rather than letting callers
@@ -114,7 +99,7 @@ class StackedPredictor(abc.ABC):
       inputs: chex.Array,
       targets: chex.Array,
       **optional_kwargs,
-      ) -> Tuple[LossAndDiagnostics, chex.Array]:
+      ) -> Tuple[StackedLossAndDiagnostics, chex.Array]:
     """Like .loss but also returns corresponding predictions.
 
     Implementing this is optional as it's not used directly by the Experiment,

--- a/graphcast/stacked_predictor_base.py
+++ b/graphcast/stacked_predictor_base.py
@@ -1,0 +1,147 @@
+# Copyright 2023 DeepMind Technologies Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Abstract base classes for an xarray-based Predictor API."""
+
+import abc
+
+from typing import Tuple
+
+from graphcast import losses
+from graphcast import xarray_jax
+import jax.numpy as jnp
+import xarray
+import chex
+
+LossAndDiagnostics = losses.LossAndDiagnostics
+
+
+class StackedPredictor(abc.ABC):
+  """A possibly-trainable predictor of weather, exposing an xarray-based API.
+
+  Typically wraps an underlying JAX model and handles translating the xarray
+  Dataset values to and from plain JAX arrays that are convenient for input to
+  (and output from) the underlying model.
+
+  Different subclasses may exist to wrap different kinds of underlying model,
+  e.g. models taking stacked inputs/outputs, models taking separate 2D and 3D
+  inputs/outputs, autoregressive models.
+
+  You can also implement a specific model directly as a Predictor if you want,
+  for example if it has quite specific/unique requirements for its input/output
+  or loss function, or if it's convenient to implement directly using xarray.
+  """
+
+  @abc.abstractmethod
+  def __call__(self,
+               inputs: chex.Array,
+               **optional_kwargs
+               ) -> chex.Array:
+    """Makes predictions.
+
+    This is only used by the Experiment for inference / evaluation, with
+    training going via the .loss method. So it should default to making
+    predictions for evaluation, although you can also support making predictions
+    for use in the loss via an is_training argument -- see
+    LossFunctionPredictor which helps with that.
+
+    Args:
+      inputs: A chex.Array of inputs and forcings.
+      **optional_kwargs: Implementations may support extra optional kwargs,
+        provided they set appropriate defaults for them.
+
+    Returns:
+      Predictions, as a chex.Array
+      For probabilistic predictors which can return multiple samples from a
+      predictive distribution, these should (by convention) be returned along
+      an additional 'sample' dimension.
+    """
+
+  def loss(self,
+           inputs: chex.Array,
+           targets: chex.Array,
+           **optional_kwargs,
+           ) -> LossAndDiagnostics:
+    """Computes a training loss, for predictors that are trainable.
+
+    Why make this the Predictor's responsibility, rather than letting callers
+    compute their own loss function using predictions obtained from
+    Predictor.__call__?
+
+    Doing it this way gives Predictors more control over their training setup.
+    For example, some predictors may wish to train using different targets to
+    the ones they predict at evaluation time -- perhaps different lead times and
+    variables, perhaps training to predict transformed versions of targets
+    where the transform needs to be inverted at evaluation time, etc.
+
+    It's also necessary for generative models (VAEs, GANs, ...) where the
+    training loss is more complex and isn't expressible as a parameter-free
+    function of predictions and targets.
+
+    Args:
+      inputs: An chex.Array.
+      **optional_kwargs: Implementations may support extra optional kwargs,
+        provided they set appropriate defaults for them.
+
+    Returns:
+      loss: A DataArray with dimensions ('batch',) containing losses for each
+        element of the batch. These will be averaged to give the final
+        loss, locally and across replicas.
+      diagnostics: Mapping of additional quantities to log by name alongside the
+        loss. These will will typically correspond to terms in the loss. They
+        should also have dimensions ('batch',) and will be averaged over the
+        batch before logging.
+        You need not include the loss itself in this dict; it will be added for
+        you.
+    """
+    del targets, forcings, optional_kwargs
+    batch_size = inputs.sizes['batch']
+    dummy_loss = xarray_jax.DataArray(jnp.zeros(batch_size), dims=('batch',))
+    return dummy_loss, {}  # pytype: disable=bad-return-type
+
+  def loss_and_predictions(
+      self,
+      inputs: chex.Array,
+      targets: chex.Array,
+      **optional_kwargs,
+      ) -> Tuple[LossAndDiagnostics, chex.Array]:
+    """Like .loss but also returns corresponding predictions.
+
+    Implementing this is optional as it's not used directly by the Experiment,
+    but it is required by autoregressive.Predictor when applying an inner
+    Predictor autoregressively at training time; we need a loss at each step but
+    also predictions to feed back in for the next step.
+
+    Note the loss itself may not be directly regressing the predictions towards
+    targets, the loss may be computed in terms of transformed predictions and
+    targets (or in some other way). For this reason we can't always cleanly
+    separate this into step 1: get predictions, step 2: compute loss from them,
+    hence the need for this combined method.
+
+    Args:
+      inputs:
+      targets:
+      **optional_kwargs:
+        As for self.loss.
+
+    Returns:
+      (loss, diagnostics)
+        As for self.loss
+      predictions:
+        The predictions which the loss relates to. These should be of the same
+        shape as what you would get from
+        `self.__call__(inputs, targets_template=targets)`, and should be in the
+        same 'domain' as the inputs (i.e. they shouldn't be transformed
+        differently to how the predictor expects its inputs).
+    """
+    raise NotImplementedError


### PR DESCRIPTION
Implements single step GraphCast including casting to half precision, dealing with normalization, and incrementing the initial conditions within InputsAndResiduals.

* main bits are in stacked_graphcast
* stacked_casting has the casting to half precision (not too complicated)
* stacked_normalization has the normalization and deals with incrementing initial conditions. This was tricky, and requires a mapping to get the indices right so that we grab the right input variables and add those to the prediction

It's maybe a bit convoluted, but the implementation can be seen in the GraphUFS repo.

Multi-timestep rollouts are future work since this already got a bit hairy... but shouldn't be too bad given that we already have the input -> target mapping for the InputsAndResiduals. 

Note that this can use the same weights files as the regular graphcast implementation. However, the loss function value is slightly different since the GraphCast loss is averaged per variable, then all the loss per variable is summed up, whereas here, we just take the global (weighted) mean. I've reconstructed the two though, and we can get the same thing, up to some precision. See other PR for that.