### PR TITLE
Drop Datetime Option

### DIFF
--- a/graphcast/autoregressive.py
+++ b/graphcast/autoregressive.py
@@ -112,7 +112,7 @@ class Predictor(predictor_base.Predictor):
                        f'forcings, which isn\'t allowed: {overlap}')
 
   def _update_inputs(self, inputs, next_frame):
-    num_inputs = inputs.dims['time']
+    num_inputs = inputs.sizes['time']
 
     predicted_or_forced_inputs = next_frame[list(inputs.keys())]
 
@@ -199,7 +199,7 @@ class Predictor(predictor_base.Predictor):
       return next_inputs, flat_pred
 
     if self._gradient_checkpointing:
-      scan_length = targets_template.dims['time']
+      scan_length = targets_template.sizes['time']
       if scan_length <= 1:
         logging.warning(
             'Skipping gradient checkpointing for sequence length of 1')

--- a/graphcast/data_utils.py
+++ b/graphcast/data_utils.py
@@ -325,6 +325,7 @@ def extract_inputs_targets_forcings(
     pressure_levels: Tuple[int, ...],
     input_duration: TimedeltaLike,
     target_lead_times: TargetLeadTimes,
+    drop_datetime: bool=True,
     ) -> Tuple[xarray.Dataset, xarray.Dataset, xarray.Dataset]:
   """Extracts inputs, targets and forcings according to requirements."""
   dataset = dataset.sel(level=list(pressure_levels))
@@ -338,7 +339,8 @@ def extract_inputs_targets_forcings(
     add_tisr_var(dataset)
 
   # `datetime` is needed by add_derived_vars but breaks autoregressive rollouts.
-  dataset = dataset.drop_vars("datetime")
+  if drop_datetime:
+    dataset = dataset.drop_vars("datetime")
 
   inputs, targets = extract_input_target_times(
       dataset,

--- a/graphcast/rollout.py
+++ b/graphcast/rollout.py
@@ -124,7 +124,7 @@ def chunked_prediction_generator(
   if "datetime" in forcings.coords:
     del forcings.coords["datetime"]
 
-  num_target_steps = targets_template.dims["time"]
+  num_target_steps = targets_template.sizes["time"]
   num_chunks, remainder = divmod(num_target_steps, num_steps_per_chunk)
   if remainder != 0:
     raise ValueError(
@@ -202,7 +202,7 @@ def _get_next_inputs(
   next_inputs = next_frame[next_inputs_keys]
 
   # Apply concatenate next frame with inputs, crop what we don't need.
-  num_inputs = prev_inputs.dims["time"]
+  num_inputs = prev_inputs.sizes["time"]
   return (
       xarray.concat(
           [prev_inputs, next_inputs], dim="time", data_vars="different")


### PR DESCRIPTION
Add an option so that we can keep (or drop, which is the default and original behavior) the datetime coordinate when creating inputs, targets, forcings. 

Also this changes the .dims -> .sizes to avoid warnings. 