### PR TITLE
StackedGraphCast: Always keep batch dim

### DIFF
--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -70,21 +70,13 @@ def stacked_mse(
         loss_per_sample_channel (chex.Array): total loss per channel and per sample
 
     """
-    # handle potential broadcasting to batch dimension
-    if predictions.ndim == 3:
-        latlon = (0, 1)
-    else:
-        latlon = (1, 2)
-        if weights is not None:
-            weights = weights[None] if weights.ndim == 3 else weights
-
     # compute loss
     loss = (predictions - targets)**2
     if weights is not None:
         loss *= weights
 
     # recall prediction shape is (samples (batch), lat, lon, channels)
-    loss_per_sample_channel = loss.sum(axis=latlon)
+    loss_per_sample_channel = loss.sum(axis=(1,2))
     loss_per_sample = loss_per_sample_channel.sum(axis=-1)
     return loss_per_sample, loss_per_sample_channel
 

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -107,8 +107,7 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         Returns:
             array with shape [latxlon, batch, channels]
         """
-
-        # NOTE: to remove this, we would have to overwrite a lot of GraphCast "batch_second_axis" code
+        # add a batch dimension if it's not already there
         inputs = inputs[None] if inputs.ndim == 3 else inputs
         result = np.moveaxis(inputs, 0, 2)
 
@@ -120,7 +119,7 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         self,
         grid_node_outputs: chex.Array,
         ) -> chex.Array:
-        """returned as [batch, lat, lon, channels] or [lat, lon, channels]"""
+        """returned as [batch, lat, lon, channels]"""
 
         assert self._grid_lat is not None and self._grid_lon is not None
         grid_shape = (self._grid_lat.shape[0], self._grid_lon.shape[0])
@@ -131,5 +130,4 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         )
         # get batch dimension first again
         result = np.moveaxis(result, 2, 0)
-        result = result.squeeze()
         return result


### PR DESCRIPTION
Previously this squeezed out the batch dimension, but this is just a pain in the MPI framework. Keeping it saves a lot of trouble.