### PR TITLE
Diagnostic Loss

### DIFF
--- a/graphcast/data_utils.py
+++ b/graphcast/data_utils.py
@@ -160,7 +160,7 @@ def add_derived_vars(data: xarray.Dataset) -> None:
     data.update(
         featurize_progress(
             name=YEAR_PROGRESS,
-            dims=batch_dim + ("time",),
+            dims=batch_dim + data["datetime"].dims,
             progress=year_progress,
         )
     )
@@ -172,7 +172,7 @@ def add_derived_vars(data: xarray.Dataset) -> None:
     data.update(
         featurize_progress(
             name=DAY_PROGRESS,
-            dims=batch_dim + ("time",) + longitude_coord.dims,
+            dims=batch_dim + data["datetime"].dims + longitude_coord.dims,
             progress=day_progress,
         )
     )

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -26,7 +26,7 @@ import xarray
 LossAndDiagnostics = tuple[xarray.DataArray, xarray.Dataset]
 
 # (total loss per sample, loss per channel per sample)
-StackedLossAndDiagnostics = tuple[chex.Array, chex.Array]
+StackedLossAndChannelLoss = tuple[chex.Array, chex.Array]
 
 
 class LossFunction(Protocol):
@@ -51,7 +51,7 @@ class LossFunction(Protocol):
       loss: A DataArray with dimensions ('batch',) containing losses for each
         element of the batch. These will be averaged to give the final
         loss, locally and across replicas.
-      diagnostics: Mapping of additional quantities to log by name alongside the
+      loss_per_variable: Mapping of additional quantities to log by name alongside the
         loss. These will will typically correspond to terms in the loss. They
         should also have dimensions ('batch',) and will be averaged over the
         batch before logging.
@@ -61,7 +61,7 @@ def stacked_mse(
     predictions: chex.Array,
     targets: chex.Array,
     weights: Optional[chex.Array | None] = None,
-) -> StackedLossAndDiagnostics:
+) -> StackedLossAndChannelLoss:
     """A very streamlined MSE loss function
     preserves final channel dimension
 

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -78,7 +78,7 @@ def stacked_mse(
     # recall prediction shape is (samples (batch), lat, lon, channels)
     loss_per_sample_channel = loss.sum(axis=(1,2))
     loss_per_sample = loss_per_sample_channel.sum(axis=-1)
-    return loss_per_sample.squeeze(), loss_per_sample_channel.squeeze()
+    return loss_per_sample, loss_per_sample_channel
 
 
 def weighted_mse_per_level(

--- a/graphcast/losses.py
+++ b/graphcast/losses.py
@@ -78,7 +78,7 @@ def stacked_mse(
     # recall prediction shape is (samples (batch), lat, lon, channels)
     loss_per_sample_channel = loss.sum(axis=(1,2))
     loss_per_sample = loss_per_sample_channel.sum(axis=-1)
-    return loss_per_sample, loss_per_sample_channel
+    return loss_per_sample.squeeze(), loss_per_sample_channel.squeeze()
 
 
 def weighted_mse_per_level(

--- a/graphcast/stacked_casting.py
+++ b/graphcast/stacked_casting.py
@@ -4,7 +4,7 @@ import contextlib
 from typing import Any, Mapping, Tuple, Optional
 
 import chex
-from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndDiagnostics
+from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndChannelLoss
 import haiku as hk
 import jax
 import jax.numpy as jnp
@@ -65,7 +65,7 @@ class StackedBfloat16Cast(Bfloat16Cast):
         inputs: chex.Array,
         targets: chex.Array,
         weights: Optional[chex.Array | None] = None
-        ) -> StackedLossAndDiagnostics:
+        ) -> StackedLossAndChannelLoss:
         if not self._enabled:
             return self._predictor.loss(inputs, targets, weights)
 
@@ -98,7 +98,7 @@ class StackedBfloat16Cast(Bfloat16Cast):
         inputs: chex.Array,
         targets: chex.Array,
         weights: Optional[chex.Array | None] = None
-        ) -> Tuple[StackedLossAndDiagnostics,
+        ) -> Tuple[StackedLossAndChannelLoss,
                    chex.Array]:
         if not self._enabled:
             return self._predictor.loss_and_predictions(

--- a/graphcast/stacked_diagnostics.py
+++ b/graphcast/stacked_diagnostics.py
@@ -47,7 +47,6 @@ class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
         diffs_stddev_by_level: dict[chex.Array, chex.Array],
         last_input_channel_mapping: dict,
         mappings: dict,
-        masks: dict,
     ):
         assert not isinstance(predictor, StackedInputsAndResiduals)
         self._predictor = predictor
@@ -57,8 +56,6 @@ class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
         self._residual_locations = {"inputs": None, "targets": None, "diagnostics": None}
         self._last_input_channel_mapping = last_input_channel_mapping
         self.mappings = mappings
-        self.masks = masks
-
 
         self._checkit(self._scales)
         self._checkit(self._locations)
@@ -75,7 +72,7 @@ class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
 
     def calc_diagnostics(self, inputs, outputs):
         return jnp.concatenate(
-            [func(inputs, outputs, self.masks) for func in self.mappings.values()],
+            [func(inputs, outputs, self.mappings["masks"], self.mappings["extra"]) for func in self.mappings["functions"].values()],
             axis=-1,
         )
 

--- a/graphcast/stacked_diagnostics.py
+++ b/graphcast/stacked_diagnostics.py
@@ -13,6 +13,7 @@ import chex
 import jax.numpy as jnp
 from typing import Optional, Tuple
 
+from graphcast.losses import stacked_mse
 from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndChannelLoss
 from graphcast.stacked_normalization import normalize, unnormalize, StackedInputsAndResiduals
 from graphcast import xarray_tree
@@ -55,6 +56,9 @@ class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
         self._residual_scales = diffs_stddev_by_level
         self._residual_locations = {"inputs": None, "targets": None, "diagnostics": None}
         self._last_input_channel_mapping = last_input_channel_mapping
+        self.mappings = mappings
+        self.masks = masks
+
 
         self._checkit(self._scales)
         self._checkit(self._locations)
@@ -112,7 +116,7 @@ class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
         predictions = self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
         prediction_diagnostics = self.calc_diagnostics(inputs, predictions)
 
-        norm_predictions = jnp.concatenate(
+        norm_preds_and_diags = jnp.concatenate(
             [norm_predictions, self.normalize_diagnostics(prediction_diagnostics)],
             axis=-1,
         )
@@ -120,13 +124,13 @@ class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
         # prepare normalized targets with normalized target diagnostics
         norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
         target_diagnostics = self.calc_diagnostics(inputs, targets)
-        norm_targets = jnp.concatenate(
+        norm_targets_and_diags = jnp.concatenate(
             [norm_target_residuals, self.normalize_diagnostics(target_diagnostics)],
             axis=-1,
         )
 
         # compute loss
-        loss, loss_per_channel = stacked_mse(norm_predictions, norm_targets, weights)
+        loss, loss_per_channel = stacked_mse(norm_preds_and_diags, norm_targets_and_diags, weights)
         predictions_with_diagnostics = jnp.concatenate(
             [predictions, prediction_diagnostics],
             axis=-1,

--- a/graphcast/stacked_diagnostics.py
+++ b/graphcast/stacked_diagnostics.py
@@ -1,0 +1,134 @@
+"""Wrappers for Predictors which allow them to work with normalized data.
+
+The Predictor which is wrapped sees normalized inputs and targets, and makes
+normalized predictions. The wrapper handles translating the predictions back
+to the original domain.
+
+Note:
+    * the loss does not pass through the half precision casting, if it exists, although the predictions do get cast to half precision
+"""
+
+import logging
+import chex
+import jax.numpy as jnp
+from typing import Optional, Tuple
+
+from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndChannelLoss
+from graphcast.stacked_normalization import normalize, unnormalize, StackedInputsAndResiduals
+from graphcast import xarray_tree
+import xarray
+
+class StackedInputsResidualsDiagnostics(StackedInputsAndResiduals):
+    """In addition to the normalization and residual framework, compute diagnostics
+    from predictions and targets that get added to the loss function.
+
+    This is tricky because:
+    * loss is computed in normalized space
+    * diagnostics are computed in un-normalized space
+
+    So the loss function has to have access to
+    * predictions: normalized and un-normalized
+    * targets: same
+    * predicted_diagnostics: normalized (and un-normalized for the routine returning predictions)
+    * predicted_targets: normalized
+
+    While it is easy to pass the prediction routine through the Bfloat16 casting,
+    it is not easy to do this for the loss function calculation...
+    So for now, predictions might be in half precision, but loss is in single.
+    This should be fine, esp. since the prediction part is where memory matters most anyway.
+    """
+
+    def __init__(
+        self,
+        predictor: StackedPredictor, # either StackedBfloat16Cast or StackedGraphCast
+        stddev_by_level: dict[chex.Array, chex.Array],
+        mean_by_level: dict[chex.Array, chex.Array],
+        diffs_stddev_by_level: dict[chex.Array, chex.Array],
+        last_input_channel_mapping: dict,
+        mappings: dict,
+        masks: dict,
+    ):
+        assert not isinstance(predictor, StackedInputsAndResiduals)
+        self._predictor = predictor
+        self._scales = stddev_by_level
+        self._locations = mean_by_level
+        self._residual_scales = diffs_stddev_by_level
+        self._residual_locations = {"inputs": None, "targets": None, "diagnostics": None}
+        self._last_input_channel_mapping = last_input_channel_mapping
+
+        self._checkit(self._scales)
+        self._checkit(self._locations)
+        self._checkit(self._residual_scales)
+
+    @staticmethod
+    def _checkit(attr):
+        if attr is not None:
+            assert isinstance(attr, dict)
+            assert "inputs" in attr.keys()
+            assert "targets" in attr.keys()
+            assert "diagnostics" in attr.keys()
+            assert len(attr.keys()) == 3
+
+    def calc_diagnostics(self, inputs, outputs):
+        return jnp.concatenate(
+            [func(inputs, outputs, self.masks) for func in self.mappings.values()],
+            axis=-1,
+        )
+
+    def normalize_diagnostics(self, outputs):
+        return normalize(outputs, self._scales["diagnostics"], self._locations["diagnostics"])
+
+    def __call__(
+        self,
+        inputs: chex.Array,
+    ) -> chex.Array:
+        predictions = super().__call__(inputs)
+        diagnostics = self.calc_diagnostics(inputs, predictions)
+        return jnp.concatenate(
+            [predictions, diagnostics],
+            axis=-1,
+        )
+
+    def loss(
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        weights: chex.Array,
+    ) -> StackedLossAndChannelLoss:
+        """Returns the loss computed on normalized inputs and targets."""
+        (loss, loss_by_channel), _ = self.loss_and_predictions(inputs, targets, weights)
+        return loss, loss_by_channel
+
+    def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
+        self,
+        inputs: chex.Array,
+        targets: chex.Array,
+        weights: chex.Array,
+    ) -> Tuple[StackedLossAndChannelLoss, chex.Array]:
+        """Note that the weights have to include the diagnostic channels too"""
+
+        # prepare normalized predictions with normalized diagnostics
+        norm_predictions = self.normalized_predict(inputs)
+        predictions = self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
+        prediction_diagnostics = self.calc_diagnostics(inputs, predictions)
+
+        norm_predictions = jnp.concatenate(
+            [norm_predictions, self.normalize_diagnostics(prediction_diagnostics)],
+            axis=-1,
+        )
+
+        # prepare normalized targets with normalized target diagnostics
+        norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
+        target_diagnostics = self.calc_diagnostics(inputs, targets)
+        norm_targets = jnp.concatenate(
+            [norm_target_residuals, self.normalize_diagnostics(target_diagnostics)],
+            axis=-1,
+        )
+
+        # compute loss
+        loss, loss_per_channel = stacked_mse(norm_predictions, norm_targets, weights)
+        predictions_with_diagnostics = jnp.concatenate(
+            [predictions, prediction_diagnostics],
+            axis=-1,
+        )
+        return (loss, loss_per_channel), predictions_with_diagnostics

--- a/graphcast/stacked_graphcast.py
+++ b/graphcast/stacked_graphcast.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from graphcast.losses import stacked_mse
-from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndDiagnostics
+from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndChannelLoss
 from graphcast.graphcast import GraphCast, ModelConfig, TaskConfig
 from graphcast import xarray_jax
 
@@ -64,27 +64,27 @@ class StackedGraphCast(GraphCast, StackedPredictor):
         inputs: chex.Array,
         targets: chex.Array,
         weights: Optional[chex.Array | None] = None,
-        ) -> tuple[StackedLossAndDiagnostics, chex.Array]:
+        ) -> tuple[StackedLossAndChannelLoss, chex.Array]:
         # Forward pass
         predictions = self(inputs)
 
         # Compute loss
-        loss, diagnostics = stacked_mse(
+        loss, loss_per_channel = stacked_mse(
             predictions=predictions,
             targets=targets,
             weights=weights,
         )
-        return (loss, diagnostics), predictions
+        return (loss, loss_per_channel), predictions
 
     def loss(
         self,
         inputs: chex.Array,
         targets: chex.Array,
         weights: Optional[chex.Array | None] = None,
-        ) -> StackedLossAndDiagnostics:
+        ) -> StackedLossAndChannelLoss:
 
-        (loss, diagnostics), _ = self.loss_and_predictions(inputs, targets, weights)
-        return loss, diagnostics
+        (loss, loss_per_channel), _ = self.loss_and_predictions(inputs, targets, weights)
+        return loss, loss_per_channel
 
 
     def _maybe_init(self):

--- a/graphcast/stacked_normalization.py
+++ b/graphcast/stacked_normalization.py
@@ -9,7 +9,7 @@ import logging
 import chex
 from typing import Optional, Tuple
 
-from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndDiagnostics
+from graphcast.stacked_predictor_base import StackedPredictor, StackedLossAndChannelLoss
 from graphcast import xarray_tree
 import xarray
 
@@ -136,7 +136,7 @@ class StackedInputsAndResiduals(StackedPredictor):
         inputs: chex.Array,
         targets: chex.Array,
         **kwargs,
-        ) -> StackedLossAndDiagnostics:
+        ) -> StackedLossAndChannelLoss:
         """Returns the loss computed on normalized inputs and targets."""
         norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
         norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
@@ -147,14 +147,14 @@ class StackedInputsAndResiduals(StackedPredictor):
         inputs: chex.Array,
         targets: chex.Array,
         **kwargs,
-        ) -> Tuple[StackedLossAndDiagnostics, chex.Array]:
+        ) -> Tuple[StackedLossAndChannelLoss, chex.Array]:
         """Returns the loss computed on normalized inputs and targets."""
         norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
         norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
-        (loss, scalars), norm_predictions = self._predictor.loss_and_predictions(
+        (loss, loss_per_channel), norm_predictions = self._predictor.loss_and_predictions(
             norm_inputs,
             norm_target_residuals,
             **kwargs,
         )
         predictions = self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
-        return (loss, scalars), predictions
+        return (loss, loss_per_channel), predictions

--- a/graphcast/stacked_normalization.py
+++ b/graphcast/stacked_normalization.py
@@ -125,28 +125,30 @@ class StackedInputsAndResiduals(StackedPredictor):
     def __call__(
         self,
         inputs: chex.Array,
-        **kwargs
         ) -> chex.Array:
-        norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
-        norm_predictions = self._predictor(norm_inputs, **kwargs)
+        norm_predictions = self.normalized_predict(inputs)
         return self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
+
+    def normalized_predict(self, inputs):
+        norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
+        return self._predictor(norm_inputs)
 
     def loss(
         self,
         inputs: chex.Array,
         targets: chex.Array,
-        **kwargs,
+        weights: chex.Array,
         ) -> StackedLossAndChannelLoss:
         """Returns the loss computed on normalized inputs and targets."""
         norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
         norm_target_residuals = self._subtract_input_and_normalize_target(inputs, targets)
-        return self._predictor.loss(norm_inputs, norm_target_residuals, **kwargs)
+        return self._predictor.loss(norm_inputs, norm_target_residuals, weights)
 
     def loss_and_predictions(  # pytype: disable=signature-mismatch  # jax-ndarray
         self,
         inputs: chex.Array,
         targets: chex.Array,
-        **kwargs,
+        weights: chex.Array,
         ) -> Tuple[StackedLossAndChannelLoss, chex.Array]:
         """Returns the loss computed on normalized inputs and targets."""
         norm_inputs = normalize(inputs, self._scales["inputs"], self._locations["inputs"])
@@ -154,7 +156,7 @@ class StackedInputsAndResiduals(StackedPredictor):
         (loss, loss_per_channel), norm_predictions = self._predictor.loss_and_predictions(
             norm_inputs,
             norm_target_residuals,
-            **kwargs,
+            weights,
         )
         predictions = self._unnormalize_prediction_and_add_input(inputs, norm_predictions)
         return (loss, loss_per_channel), predictions

--- a/graphcast/stacked_predictor_base.py
+++ b/graphcast/stacked_predictor_base.py
@@ -8,7 +8,7 @@ import jax.numpy as jnp
 import xarray
 import chex
 
-StackedLossAndDiagnostics = losses.StackedLossAndDiagnostics
+StackedLossAndChannelLoss = losses.StackedLossAndChannelLoss
 
 
 class StackedPredictor(abc.ABC):
@@ -56,7 +56,7 @@ class StackedPredictor(abc.ABC):
            inputs: chex.Array,
            targets: chex.Array,
            **optional_kwargs,
-           ) -> StackedLossAndDiagnostics:
+           ) -> StackedLossAndChannelLoss:
     """Computes a training loss, for predictors that are trainable.
 
     Why make this the Predictor's responsibility, rather than letting callers
@@ -82,7 +82,7 @@ class StackedPredictor(abc.ABC):
       loss: A DataArray with dimensions ('batch',) containing losses for each
         element of the batch. These will be averaged to give the final
         loss, locally and across replicas.
-      diagnostics: Mapping of additional quantities to log by name alongside the
+      loss_per_channel: Mapping of additional quantities to log by name alongside the
         loss. These will will typically correspond to terms in the loss. They
         should also have dimensions ('batch',) and will be averaged over the
         batch before logging.
@@ -99,7 +99,7 @@ class StackedPredictor(abc.ABC):
       inputs: chex.Array,
       targets: chex.Array,
       **optional_kwargs,
-      ) -> Tuple[StackedLossAndDiagnostics, chex.Array]:
+      ) -> Tuple[StackedLossAndChannelLoss, chex.Array]:
     """Like .loss but also returns corresponding predictions.
 
     Implementing this is optional as it's not used directly by the Experiment,
@@ -120,7 +120,7 @@ class StackedPredictor(abc.ABC):
         As for self.loss.
 
     Returns:
-      (loss, diagnostics)
+      (loss, loss_per_channel)
         As for self.loss
       predictions:
         The predictions which the loss relates to. These should be of the same


### PR DESCRIPTION
This makes the changes in the graphcast code base necessary for computing the diagnostics before computing the loss.

This is a bit tricky because the actual model operates on the normalized variables, but we want the diagnostics to be computed with the un-normalized variables. Then we have to normalize the diagnostics. Hence, a new module is required to do all this trickery.